### PR TITLE
Replace deprecated widget constructors

### DIFF
--- a/widgets/coming_events.php
+++ b/widgets/coming_events.php
@@ -1,15 +1,24 @@
 <?php
 
-add_action('widgets_init', create_function('', 'return register_widget("salsapress_coming_events");'));
+add_action( 'widgets_init', function () {
+	register_widget( 'Salsapress_Coming_Events' );
+} );
 
-// Jolokia Salsa Event Widget
-class salsapress_coming_events extends WP_Widget
-{
-  function salsapress_coming_events()
-  {
-    $widget_ops = array('description' => __('Coming events, pulled out of Salsa.'));
-    $this->WP_Widget('salsapress_coming_events_widget', __('Salsa Events'), $widget_ops);
-  }
+/**
+ * Jolokia Salsa Coming Events Widget
+ */
+class Salsapress_Coming_Events extends WP_Widget {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct(
+			'salsapress_coming_events_widget',
+			__( 'Salsa Events', 'salsapress' ),
+			array( 'description' => __( 'Coming events, pulled out of Salsa.', 'salsapress' ) )
+		);
+	}
 
   function form($instance)
   {

--- a/widgets/event_form.php
+++ b/widgets/event_form.php
@@ -1,15 +1,23 @@
 <?php
 
-add_action('widgets_init', create_function('', 'return register_widget("salsa_event_widget");'));
+add_action( 'widgets_init', function () {
+	register_widget( 'Salsa_Event_Widget' );
+} );
 
-// Jolokia Salsa Event Widget
-class salsa_event_widget extends WP_Widget
-{
-  function salsa_event_widget()
-  {
-    $widget_ops = array('description' => __('Add an event form from Salsa'));
-    $this->WP_Widget('salsapress_event_form_widget', __('Salsa Event Form'), $widget_ops);
-  }
+/**
+ * Jolokia Salsa Event Form Widget
+ */
+class Salsa_Event_Widget extends WP_Widget {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct(
+			'salsapress_event_widget',
+			__( 'Salsa Event Form', 'salsapress' ),
+			array( 'description' => __( 'Add an event form from Salsa', 'salsapress' ) )
+		);
+	}
 
   function form($instance)
   {

--- a/widgets/petition.php
+++ b/widgets/petition.php
@@ -1,15 +1,24 @@
 <?php
 
-add_action('widgets_init', create_function('', 'return register_widget("salsa_petition_widget");'));
+add_action( 'widgets_init', function () {
+	register_widget( 'Salsapress_Petition_Widget' );
+} );
 
-// Jolokia Salsa Event Widget
-class salsa_petition_widget extends WP_Widget
-{
-  function salsa_petition_widget()
-  {
-    $widget_ops = array('description' => __('Add a petition from Salsa','salsapress'));
-    $this->WP_Widget('salsapress_salsa_petition_widget', __('Salsa Petition','salsapress'), $widget_ops);
-  }
+/**
+ * Jolokia Salsa Petition Widget
+ */
+class Salsapress_Petition_Widget extends WP_Widget {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct(
+			'salsapress_salsa_petition_widget',
+			__( 'Salsa Petition', 'salsapress' ),
+			array( 'description' => __( 'Add a petition from Salsa', 'salsapress' ) )
+		);
+	}
 
   function form($instance)
   {

--- a/widgets/signup_page.php
+++ b/widgets/signup_page.php
@@ -1,15 +1,24 @@
 <?php
 
-add_action('widgets_init', create_function('', 'return register_widget("salsa_signup_widget");'));
+add_action( 'widgets_init', function () {
+	register_widget( 'Salsa_Signup_Widget' );
+} );
 
-// Jolokia Salsa Event Widget
-class salsa_signup_widget extends WP_Widget
-{
-  function salsa_signup_widget()
-  {
-    $widget_ops = array('description' => __('Add a sign up form from Salsa','salsapress'));
-    $this->WP_Widget('salsapress_signup_form_widget', __('Salsa Sign Up Form','salsapress'), $widget_ops);
-  }
+/**
+ * Jolokia Salsa Signup Widget
+ */
+class Salsa_Signup_Widget extends WP_Widget {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct(
+			'salsa_signup_form_widget',
+			__( 'Salsa Sign Up Form', 'salsapress' ),
+			array( 'description' => __( 'Add a sign up form from Salsa', 'salsapress' ) )
+		);
+	}
 
   function form($instance)
   {


### PR DESCRIPTION
Installed this on a sandbox WP install and got deprecated notices for php 4 style constructors. Now that php 7 is out, these will crash and burn on WP+php7 installs. This replaces the php 4 widget constructors with php 5+ constructors.
Cheers!
